### PR TITLE
Symfony 5 compatibility

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,8 +14,8 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sylius_seo_url_plugin');
+        $treeBuilder = new TreeBuilder('sylius_seo_url_plugin');
+        $rootNode = $treeBuilder->getRootNode();
 
         return $treeBuilder;
     }


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.